### PR TITLE
event schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,43 +4,44 @@ within a PostgreSQL db, with a thin frontend provided by
 [PostgREST](http://postgrest.org/en/v7.0.0/index.html)
 
 ## Event Schema
-**logserver** is agnostic to the format of events, provided it's valid JSON.
-The following suggestions enable common query syntax and meet expectations.
+**logserver** is agnostic to the format, provided it's valid JSON.  Any number
+of database tables can be used, but only the single **"events"** table is built
+in, containing a PostgreSQL JSONB column,  **"event"**.
+
+The following suggestions for the format of each "event" entry enable common
+query syntax and meet expectations.
 
 A distinction is made between "top level" attributes, and those nested under
 "message".  The "message" may be a simple text string, or any level of valid
 JSON data, intended to capture the intent of the event, such as "new consent
-signed" or "search for <...> found 0 matches".
+signed" or "search for <...> found 0 matches".  Message generally captures
+the specific context from the code of the event being tracked, with all other
+details collected by a routine that can collect and populate the other top
+level attributes as specified below.
 
-Tags is a list of strings defining general event types, with the intent to
-make filtering or searching easy.
-
-All other top level attributes are generally consistent on any given system,
-defining the source, user, system type, time of event, etc.
-
-The following should be common to all events and are generally built in:
+The following should be common to all events on a given system:
 ```json
 {
     "version": "1", // the event schema version, not the application version
     "asctime": "", // ISO-8601 format including time-zone offset, preferably in UTC
     "name": "", // Application code package name, often built in to the logging system and difficult to manipulate
-    "level": "INFO", // Built in to the logging package, typical values include DEBUG, WARN, ERROR
+    "level": "INFO", // Built in to the logging package, options also include DEBUG, WARN, ERROR
 ```
 
-System identifiers to uniquely specify the source of the event. 
+System identifiers to uniquely specify the source of the event:
 ```json
     "clinical-site": "", // unique name when appropriate to define jurisdiction, institution or clinic, such as "UW Harborview",
     "deployment": "", // one of ["dev", "test", "demo", "stage", "prod"]
-    "system-type": "", // such as "remote" or "kiosk"
+    "system-type": "", // such as "remote" or "kiosk", if applicable
     "system-name": "", // system identifier URL
 ```
 
-If acting on an identifiable entity "subject", such as "Patient/12"
+If acting on an identifiable entity "subject":
 ```json
     "subject": "Patient/12
 ```
 
-List of topics useful for filtering
+List of topics useful for filtering:
 ```json
     "tags": ["patient", "launch", "logout", "search"], // one or more
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ JSON data, intended to capture the intent of the event, such as "new consent
 signed" or "search for <...> found 0 matches".  Message generally captures
 the specific context from the code of the event being tracked, with all other
 details collected by a routine that can collect and populate the other top
-level attributes as specified below.
+level attributes as specified below.  
+
+Since we anticipate that events will undergo automated processing and there is only a single 'message' attribute, it seems likely that a message will have several json attributes, rather than be a simple string.  But, either is legal.
 
 The following should be common to all events on a given system:
 ```json

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ If acting on an identifiable entity "subject":
     "subject": "Patient/12",
 ```
 
-List of topics useful for filtering:
+List of topics (effectively a message "type" or "reason") useful for filtering:
 ```json
-    "tags": ["patient", "launch", "logout", "search"], // one or more
+    "tags": ["patient", "launch", "logout", "search"], // one or more tags
 ```
 
 And finally, and details in the message itself, that aren't captured above,

--- a/README.md
+++ b/README.md
@@ -3,6 +3,45 @@ API and storage for logging, event and audit messages, persisted in JSON
 within a PostgreSQL db, with a thin frontend provided by
 [PostgREST](http://postgrest.org/en/v7.0.0/index.html)
 
+## Event Schema
+*logserver* is agnostic to format of events, provided it's valid JSON.  The
+following suggestions enable common query syntax and expectations:
+
+A distinction is made between "top level" attributes, and those nested under
+"message".  The "message" may be a simple text string, or any level of valid
+JSON data, intended to capture the intent of the event, such a "patient/12 deleted" or "search for {...} found 0 matches".
+
+Tags is a list of strings defining general event types, with the intent to
+make filtering or searching easy.
+
+All other top level attributes are generally consistent on any given system,
+defining the source, user, system type, time of event, etc.
+
+```json
+{
+"version": "1", // the event schema version, not the application version
+"asctime": "", // ISO-8601 format including time-zone offset, preferably in UTC
+
+```
+
+1. Top level attributes, such as "version" and "asctime", are typically
+consistent across all event types.  For example, "user" is generally the
+authenticated user, and available on most all events.
+2. "message", itself a top level attribute, captures the unique nature of
+the event being logged.  Examples might include "session created" or "question 1.1 skipped" and may also include any number of nested fields.
+3. "tags", itself a top level attribute, captures single term identifiers,
+useful in filtering.  Examples include "search", "logout", "patient", etc.
+4. "name", often derrived from the code module executing, not easily controlled.
+5. "clinical-site", unique name when appropriate to define jurisdiction, institution or clinic, such as "UW Harborview"
+6. "deployment", one of ["dev", "test", "demo", "stage", "prod"]
+7. "system-type", such as "remote" or "kiosk"
+8. "system-name", system identifier URL
+
+Project - Version examples for formatting `events`
+
+* [COSRI - version 0](./docs/cosri_v0.md)
+* [COSRI - version 1](./docs/cosri_v1.md)
+
 ## Config
 Copy ``default.env`` to ``.env`` and edit.  Don't quote strings!
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following should be common to all events on a given system:
 ```json
 {
     "event_version": "1", // the event schema version
-    "asctime": "", // ISO-8601 format including time-zone offset, preferably in UTC
+    "asctime": "", // ISO-8601 format including time-zone offset
     "name": "", // Application code package name, often built in to the logging system and difficult to manipulate
     "level": "INFO", // Built in to the logging package, options also include DEBUG, WARN, ERROR
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ level attributes as specified below.
 The following should be common to all events on a given system:
 ```json
 {
-    "version": "1", // the event schema version, not the application version
+    "event_version": "1", // the event schema version
     "asctime": "", // ISO-8601 format including time-zone offset, preferably in UTC
     "name": "", // Application code package name, often built in to the logging system and difficult to manipulate
     "level": "INFO", // Built in to the logging package, options also include DEBUG, WARN, ERROR
@@ -33,12 +33,17 @@ System identifiers to uniquely specify the source of the event:
     "clinical-site": "", // unique name when appropriate to define jurisdiction, institution or clinic, such as "UW Harborview",
     "deployment": "", // one of ["dev", "test", "demo", "stage", "prod"]
     "system-type": "", // such as "remote" or "kiosk", if applicable
-    "system-name": "", // system identifier URL
+    "system-url": "", // system identifier URL
+```
+
+Authenticated user, or string identifier for system run jobs, etc.
+```json
+    "user": "User/1", // alternative nested JSON with attributes is fine; ideally consistent per application
 ```
 
 If acting on an identifiable entity "subject":
 ```json
-    "subject": "Patient/12
+    "subject": "Patient/12",
 ```
 
 List of topics useful for filtering:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ within a PostgreSQL db, with a thin frontend provided by
 
 ## Event Schema
 *logserver* is agnostic to format of events, provided it's valid JSON.  The
-following suggestions enable common query syntax and expectations:
+following suggestions enable common query syntax and expectations.
 
 A distinction is made between "top level" attributes, and those nested under
 "message".  The "message" may be a simple text string, or any level of valid
@@ -17,27 +17,43 @@ make filtering or searching easy.
 All other top level attributes are generally consistent on any given system,
 defining the source, user, system type, time of event, etc.
 
+The following should be common to all events and are generally built in:
 ```json
 {
-"version": "1", // the event schema version, not the application version
-"asctime": "", // ISO-8601 format including time-zone offset, preferably in UTC
-
+    "version": "1", // the event schema version, not the application version
+    "asctime": "", // ISO-8601 format including time-zone offset, preferably in UTC
+    "name": "", // Application code package name, often built in to the logging system and difficult to manipulate
+    "level": "INFO", // Built in to the logging package, typical values include DEBUG, WARN, ERROR
 ```
 
-1. Top level attributes, such as "version" and "asctime", are typically
-consistent across all event types.  For example, "user" is generally the
-authenticated user, and available on most all events.
-2. "message", itself a top level attribute, captures the unique nature of
-the event being logged.  Examples might include "session created" or "question 1.1 skipped" and may also include any number of nested fields.
-3. "tags", itself a top level attribute, captures single term identifiers,
-useful in filtering.  Examples include "search", "logout", "patient", etc.
-4. "name", often derrived from the code module executing, not easily controlled.
-5. "clinical-site", unique name when appropriate to define jurisdiction, institution or clinic, such as "UW Harborview"
-6. "deployment", one of ["dev", "test", "demo", "stage", "prod"]
-7. "system-type", such as "remote" or "kiosk"
-8. "system-name", system identifier URL
+System identifiers to uniquely specify the source of the event. 
+```json
+    "clinical-site": "", // unique name when appropriate to define jurisdiction, institution or clinic, such as "UW Harborview",
+    "deployment": "", // one of ["dev", "test", "demo", "stage", "prod"]
+    "system-type": "", // such as "remote" or "kiosk"
+    "system-name": "", // system identifier URL
+```
 
-Project - Version examples for formatting `events`
+If acting on an identifiable entity "subject", such as "Patient/12"
+```json
+    "subject": "Patient/12
+```
+
+List of topics useful for filtering
+```json
+    "tags": ["patient", "launch", "logout", "search"],
+```
+
+And finally, and details in the message itself, that aren't captured above,
+nesting any valid JSON within message if appropriate.  The details captured
+in the "message" often come from deep in the application stack, where all of
+the above isn't so easily obtained.
+```json
+    "message": "Description of action"
+}
+```
+
+###Project - Version schema examples for formatting `events`:
 
 * [COSRI - version 0](./docs/cosri_v0.md)
 * [COSRI - version 1](./docs/cosri_v1.md)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # logserver
-API and storage for logging, event and audit messages, persisted in JSON
+API and storage for logging event and audit messages, persisted in JSON
 within a PostgreSQL db, with a thin frontend provided by
 [PostgREST](http://postgrest.org/en/v7.0.0/index.html)
 
 ## Event Schema
-*logserver* is agnostic to format of events, provided it's valid JSON.  The
-following suggestions enable common query syntax and expectations.
+**logserver** is agnostic to the format of events, provided it's valid JSON.
+The following suggestions enable common query syntax and meet expectations.
 
 A distinction is made between "top level" attributes, and those nested under
 "message".  The "message" may be a simple text string, or any level of valid
-JSON data, intended to capture the intent of the event, such a "patient/12 deleted" or "search for {...} found 0 matches".
+JSON data, intended to capture the intent of the event, such as "new consent
+signed" or "search for <...> found 0 matches".
 
 Tags is a list of strings defining general event types, with the intent to
 make filtering or searching easy.
@@ -41,7 +42,7 @@ If acting on an identifiable entity "subject", such as "Patient/12"
 
 List of topics useful for filtering
 ```json
-    "tags": ["patient", "launch", "logout", "search"],
+    "tags": ["patient", "launch", "logout", "search"], // one or more
 ```
 
 And finally, and details in the message itself, that aren't captured above,
@@ -49,11 +50,11 @@ nesting any valid JSON within message if appropriate.  The details captured
 in the "message" often come from deep in the application stack, where all of
 the above isn't so easily obtained.
 ```json
-    "message": "Description of action"
+    "message": "Description of action" // replace string with nested JSON when applicable 
 }
 ```
 
-###Project - Version schema examples for formatting `events`:
+### Example event schemas in use for the respective projects:
 
 * [COSRI - version 0](./docs/cosri_v0.md)
 * [COSRI - version 1](./docs/cosri_v1.md)

--- a/docs/cosri_v0.md
+++ b/docs/cosri_v0.md
@@ -37,7 +37,9 @@
 ```json
 {
     "name": "sof_wrapper",
-    "user": {"DEA": "testDEAvalue", "username": "test"},
+    "user": {
+        "DEA": "testDEAvalue",
+	"username": "test"},
     "asctime": "2021-09-14 17:58:53,930",
     "message": "PDMP returned 3 MedicationRequest/Orders",
     "subject": "Patient/1",

--- a/docs/cosri_v0.md
+++ b/docs/cosri_v0.md
@@ -1,0 +1,61 @@
+# NB Version 0, didn't include a "version" attribute.
+
+# Smart On Fire /launch event:
+```json
+{
+    "name": "sof_wrapper",
+    "tags": ["launch"],
+    "asctime": "2021-09-14 17:52:31,516",
+    "message": "launch",
+    "subject": "Patient/1",
+    "levelname": "INFO"
+}
+```
+
+# PDMP event: patient lookup success
+```json
+{
+    "name": "patientsearch",
+    "tags": ["search"],
+    "user": {
+        "DEA": "testDEAvalue",
+	"username": "test"
+    },
+    "asctime": "2021-09-14 18:01:50,224",
+    "message": "PDMP found match",
+    "patient": {
+        "subject.id": "2",
+	"subject:Patient.birthdate": "eq1974-09-01",
+	"subject:Patient.name.given": "Harry",
+	"subject:Patient.name.family": "Osborn"
+    },
+    "levelname": "INFO"
+}
+```
+
+# PDMP event: medication requests found
+```json
+{
+    "name": "sof_wrapper",
+    "user": {"DEA": "testDEAvalue", "username": "test"},
+    "asctime": "2021-09-14 17:58:53,930",
+    "message": "PDMP returned 3 MedicationRequest/Orders",
+    "subject": "Patient/1",
+    "levelname": "INFO"
+}
+```
+
+# FEMR (patientsearch) initiated logout
+```json
+{
+    "name": "patientsearch",
+    "tags": ["logout"],
+    "user": {
+        "DEA": "testDEAvalue",
+	"username": "test"
+    },
+    "asctime": "2021-09-17 00:04:08,187",
+    "message": "logout on request",
+    "levelname": "INFO"
+}
+```

--- a/docs/cosri_v1.md
+++ b/docs/cosri_v1.md
@@ -1,0 +1,67 @@
+
+# Smart On Fire /launch event:
+```json
+{
+    "version": "1",
+    "name": "sof_wrapper",
+    "tags": ["launch"],
+    "asctime": "2021-09-14 17:52:31,516",
+    "message": "launch",
+    "subject": "Patient/1",
+    "levelname": "INFO"
+}
+```
+
+# PDMP event: patient lookup success
+```json
+{
+    "version": "1",
+    "name": "patientsearch",
+    "tags": ["search"],
+    "user": {
+        "DEA": "testDEAvalue",
+	"username": "test"
+    },
+    "asctime": "2021-09-14 18:01:50,224",
+    "message": "PDMP found match",
+    "patient": {
+        "subject.id": "2",
+	"subject:Patient.birthdate": "eq1974-09-01",
+	"subject:Patient.name.given": "Harry",
+	"subject:Patient.name.family": "Osborn"
+    },
+    "levelname": "INFO"
+}
+```
+
+# PDMP event: medication requests found
+```json
+{
+    "version": "1",
+    "name": "sof_wrapper",
+    "user": {
+        "DEA": "testDEAvalue",
+	"username": "test"
+    },
+    "asctime": "2021-09-14 17:58:53,930",
+    "message": "PDMP returned 3 MedicationRequest/Orders",
+    "subject": "Patient/1",
+    "levelname": "INFO"
+}
+```
+
+# FEMR (patientsearch) initiated logout
+```json
+{
+    "version": "1",
+    "name": "patientsearch",
+    "tags": ["logout"],
+    "user": {
+        "DEA": "testDEAvalue",
+	"username": "test"
+    },
+    "asctime": "2021-09-17 00:04:08,187",
+    "message": "logout on request",
+    "levelname": "INFO"
+}
+```

--- a/docs/cosri_v1.md
+++ b/docs/cosri_v1.md
@@ -5,7 +5,10 @@
     "version": "1",
     "name": "sof_wrapper",
     "tags": ["launch"],
-    "asctime": "2021-09-14 17:52:31,516",
+    "asctime": "2021-09-14 17:52:31,516+00:00",
+    "clinical-site": "Demo",
+    "deployment": "demo",
+    "system-name": "http://backend.cosri-demo.cirg.washington.edu/",
     "message": "launch",
     "subject": "Patient/1",
     "levelname": "INFO"
@@ -22,7 +25,10 @@
         "DEA": "testDEAvalue",
 	"username": "test"
     },
-    "asctime": "2021-09-14 18:01:50,224",
+    "asctime": "2021-09-14 18:01:50,224+00:00",
+    "clinical-site": "Demo",
+    "deployment": "demo",
+    "system-name": "http://pdmp.cosri-demo.cirg.washington.edu/",
     "message": "PDMP found match",
     "patient": {
         "subject.id": "2",
@@ -43,7 +49,10 @@
         "DEA": "testDEAvalue",
 	"username": "test"
     },
-    "asctime": "2021-09-14 17:58:53,930",
+    "asctime": "2021-09-14 17:58:53,930+00:00",
+    "clinical-site": "Demo",
+    "deployment": "demo",
+    "system-name": "http://backend.cosri-demo.cirg.washington.edu/",
     "message": "PDMP returned 3 MedicationRequest/Orders",
     "subject": "Patient/1",
     "levelname": "INFO"
@@ -60,7 +69,10 @@
         "DEA": "testDEAvalue",
 	"username": "test"
     },
-    "asctime": "2021-09-17 00:04:08,187",
+    "asctime": "2021-09-17 00:04:08,187+00:00",
+    "clinical-site": "Demo",
+    "deployment": "demo",
+    "system-name": "http://dashboard.cosri-demo.cirg.washington.edu/",
     "message": "logout on request",
     "levelname": "INFO"
 }


### PR DESCRIPTION
Extending the README to include suggested details for how to format `event`s to make for consistent queries, and track all necessary data.