### PR TITLE
Added healthcheck and condition to remove bootstrap errors

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,8 @@ services:
       PGRST_DB_ANON_ROLE: web_anon
       PGRST_JWT_SECRET: ${PGRST_JWT_SECRET}
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 
   postgres:
     image: postgres:${POSTGRES_IMAGE_TAG:-12}
@@ -23,6 +24,11 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./sql/init.sql:/docker-entrypoint-initdb.d/init.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app_user -d app_db"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
 volumes:
   postgres-data: {}


### PR DESCRIPTION
added `healthcheck` to `postgres`, and now waiting for postgres to be healthy before starting postgREST.

the eliminates logging noise/errors on startup.