### PR TITLE
generate jwt utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,15 @@ web_anon | read only access to the API
 event_logger | read / write access to the API
 
 ## Access via JWT
-For write access, generate a JWT at [jwt.io](https://jwt.io/#debugger-io)
+For write access, generate a JWT using the `generate_JWT.py` script in root
+of project:
 
-* Replace ``secret`` with the *unquoted* value of ``PGRST_JWT_SECRET``
-* Replace the ``PAYLOAD: DATA`` with the appropriate role
+```bash
+pip install pyjwt
+JWT=`python3 generate_JWT.py`
+```
+
+or use any other approach signing with the configured value of ``PGRST_JWT_SECRET`` (hint: see `.env`) and the following payload:
 
 ```javascript
 {
@@ -96,7 +101,6 @@ For write access, generate a JWT at [jwt.io](https://jwt.io/#debugger-io)
 }
 ```  
 
-* Do NOT check the ``secret base64 encoded`` checkbox
 * Save the ``Encoded`` JWT for use, passing as a bearer token:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Basic Audit Log Patterns
 [(BALP)](https://profiles.ihe.net/ITI/BALP/volume-1.html#1-52-basic-audit-log-patterns) 
 implementation guide.
 
+## Table of Contents
+- [Event Schema](#event-schema-version-30)
+  - [Project Specific Examples](#example-event-schemas-in-use-for-the-respective-projects)
+- [Config](#config)
+- [Roles](#roles)
+- [Access via JWT](#access-via-jwt)
+- [API use](#api-use)
+- [Advanced Query Examples](#advanced-query-examples)
+- [Direct DB access](#db-access)
+- [Reporting tools](#reporting-tools-that-use-data-from-logserver)
+
 ## Event Schema (version 3.0)
 **logserver** is agnostic to the format, provided it is valid JSON.  Any number
 of database tables can be used, but only the single `events` table is built
@@ -140,6 +151,48 @@ Fetch events based on datetime, and include a number of isacc-specific fields:
 See [PostgREST API](http://postgrest.org/en/v7.0.0/api.html) documentation
 for additional options
 
+## Advanced Query Examples
+
+Example to find `letstalktech` events filtered by source.  Using 
+[direct database access](#direct-db-access), look up available source
+from the development logserver `logs.inform.dev.cirg.uw.edu`:
+
+```sql
+select distinct(event->'source'->>'type') from events;
+    ?column?
+-----------------
+ dhair2/inform
+ shl-ltt-server
+ shl-ltt
+ external-client
+```
+
+Request all events of `source->type` = `shl-ltt-server`, from the dev `letstalktech` logserver:
+
+[https://logs.inform.dev.cirg.uw.edu/events?select=event&event->source->>type=eq.shl-ltt-server](https://logs.inform.dev.cirg.uw.edu/events?select=event&event-%3Esource-%3E%3Etype=eq.shl-ltt-server)
+
+or the first 10 with `source_type` = `shl-ltt-server` since Jan 30, 2025:
+
+[https://logs.inform.dev.cirg.uw.edu/events?select=event&event->source->>type=eq.shl-ltt-server&event->>occurred=gte.2025-01-30&order=event->>occurred&limit=10](https://logs.inform.dev.cirg.uw.edu/events?select=event&event-%3Esource-%3E%3Etype=eq.shl-ltt-server&event-%3E%3Eoccurred=gte.2025-01-30&order=event-%3E%3Eoccurred&limit=10)
+
+or only the `event->occurred` from the first 10 with `source_type` = `shl-ltt` since Jan 30, 2025:
+
+[https://logs.inform.dev.cirg.uw.edu/events?select=event->occurred&event-%3Esource->>type=eq.shl-ltt&event->>occurred=gte.2025-01-30&order=event->>occurred&limit=10](https://logs.inform.dev.cirg.uw.edu/events?select=event-%3Eoccurred&event-%3Esource-%3E%3Etype=eq.shl-ltt&event-%3E%3Eoccurred=gte.2025-01-30&order=event-%3E%3Eoccurred&limit=10)
+
+
+## Direct DB Access
+
+To access the backing postgres database, invoke `docker compose` from the
+deployed directory as follows:
+
+```
+docker compose exec postgres psql postgres://app_user:secret@postgres:5432/app_db -c '\dt api.*'
+```
+
+To simplify queries, set `api` as the search path, to make it the default schema:
+```sql
+SET search_path TO api;
+```
 ## Reporting tools that use data from logserver
 - https://github.com/uwcirg/gwen
 - https://github.com/uwcirg/logserver-tabulator

--- a/generate_JWT.py
+++ b/generate_JWT.py
@@ -18,12 +18,11 @@ except subprocess.CalledProcessError as e:
     sys.exit(1)
 
 try:
-    secret_base64 = config['services']['postgrest']['environment']['PGRST_JWT_SECRET']
+    secret = config['services']['postgrest']['environment']['PGRST_JWT_SECRET']
 except KeyError:
     print("Error, PGRST_JWT_SECRET not defined")
     sys.exit(1)
 
-secret = base64.b64decode(secret_base64)
 payload = {"role": "event_logger"}
 token = jwt.encode(payload, secret, algorithm="HS256")
 

--- a/generate_JWT.py
+++ b/generate_JWT.py
@@ -1,0 +1,16 @@
+import jwt
+import base64
+import sys
+
+if len(sys.argv) != 2:
+    print("Usage: generate_JWT.py <base64-encoded-secret-key>")
+    sys.exit(1)
+
+secret_base64 = sys.argv[1]
+secret = base64.b64decode(secret_base64)
+payload = {"role": "event_logger"}
+token = jwt.encode(payload, secret, algorithm="HS256")
+
+# echo JWT
+print(token)
+

--- a/generate_JWT.py
+++ b/generate_JWT.py
@@ -5,9 +5,9 @@ import subprocess
 import sys
 
 try:
-    # capture output from docker compose config
+    # capture output from `docker compose config`
     result = subprocess.run(
-        ["docker compose", "config"],
+        ["docker", "compose", "config"],
         capture_output=True,
         text=True,
         check=True,

--- a/generate_JWT.py
+++ b/generate_JWT.py
@@ -5,16 +5,16 @@ import subprocess
 import sys
 
 try:
-    # capture output from docker-compose config
+    # capture output from docker compose config
     result = subprocess.run(
-        ["docker-compose", "config"],
+        ["docker compose", "config"],
         capture_output=True,
         text=True,
         check=True,
     )
     config = yaml.safe_load(result.stdout)
 except subprocess.CalledProcessError as e:
-    print("Error calling `docker-compose config`:", e)
+    print("Error calling `docker compose config`:", e)
     sys.exit(1)
 
 try:

--- a/generate_JWT.py
+++ b/generate_JWT.py
@@ -1,12 +1,28 @@
-import jwt
 import base64
+import jwt
+import yaml
+import subprocess
 import sys
 
-if len(sys.argv) != 2:
-    print("Usage: generate_JWT.py <base64-encoded-secret-key>")
+try:
+    # capture output from docker-compose config
+    result = subprocess.run(
+        ["docker-compose", "config"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    config = yaml.safe_load(result.stdout)
+except subprocess.CalledProcessError as e:
+    print("Error calling `docker-compose config`:", e)
     sys.exit(1)
 
-secret_base64 = sys.argv[1]
+try:
+    secret_base64 = config['services']['postgrest']['environment']['PGRST_JWT_SECRET']
+except KeyError:
+    print("Error, PGRST_JWT_SECRET not defined")
+    sys.exit(1)
+
 secret = base64.b64decode(secret_base64)
 payload = {"role": "event_logger"}
 token = jwt.encode(payload, secret, algorithm="HS256")


### PR DESCRIPTION
Previously, the README directed users to https://jwt.io to generate a JWT token by hand.

That service is no longer accepting base64 encoded keys - added a simple utility that:
1. parses the value of `PGRST_JWT_SECRET` directly from `docker-compose config`
2. generates a compliant JWT for debugging and POSTing to logserver