### PR TITLE
split database init files

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       POSTGRES_PASSWORD: secret
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - ./sql/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./sql:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U app_user -d app_db"]
       interval: 5s

--- a/sql/01_create-tables.sql
+++ b/sql/01_create-tables.sql
@@ -1,0 +1,9 @@
+-- create schema used for API
+create schema api;
+
+-- create table used for log events
+create table api.events (
+	id serial primary key,
+	event jsonb not null
+);
+

--- a/sql/02_create-roles.sql
+++ b/sql/02_create-roles.sql
@@ -1,19 +1,23 @@
--- create schema used for API
-create schema api;
-
--- create table used for log events
-create table api.events (
-	id serial primary key,
-	event jsonb not null
-);
 
 -- create web user w/ read only auth
-create role web_anon nologin;
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'web_anon') THEN
+    create role web_anon nologin;
+  END IF;
+END $$;
+
 grant usage on schema api to web_anon;
 grant select on api.events to web_anon;
 
 -- create privileged user to write events
-create role event_logger nologin;
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'event_logger') THEN
+    create role event_logger nologin;
+  END IF;
+END $$;
+
 grant usage on schema api to event_logger;
 grant all on api.events to event_logger;
 grant usage, select on sequence api.events_id_seq to event_logger;

--- a/sql/02_create-roles.sql
+++ b/sql/02_create-roles.sql
@@ -1,23 +1,11 @@
 
 -- create web user w/ read only auth
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'web_anon') THEN
-    create role web_anon nologin;
-  END IF;
-END $$;
-
+create role web_anon nologin;
 grant usage on schema api to web_anon;
 grant select on api.events to web_anon;
 
 -- create privileged user to write events
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'event_logger') THEN
-    create role event_logger nologin;
-  END IF;
-END $$;
-
+create role event_logger nologin;
 grant usage on schema api to event_logger;
 grant all on api.events to event_logger;
 grant usage, select on sequence api.events_id_seq to event_logger;


### PR DESCRIPTION
Broke steps in single database `init.sql` file, into distinct steps, files named to control evaluation order.
This enables easier import of any given step into a live DB, and paves the road for easier view development.