### PR TITLE
Fix: Update events_view logic for schema_version determination

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,6 +1,5 @@
 name: Python Tests
 
-
 # 1. Run on every push
 on:
   push: {}
@@ -30,7 +29,6 @@ jobs:
       # 4. Check out code
       - uses: actions/checkout@v3
 
-
       # 5. Create test database & apply schema
       - name: Initialize database
         env:
@@ -42,12 +40,10 @@ jobs:
           psql -h localhost -U postgres -c "CREATE DATABASE test_db;"
 
       # 6. Set up Python
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-
 
       # 7. Load the integration dump so tests/test_integration_logs.py has data
       - name: Load `logs100.sql` Dataset (includes schema)
@@ -69,4 +65,3 @@ jobs:
           # override default app_db URL so pytest runs against test_db
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/test_db
         run: pytest --maxfail=1 --disable-warnings -v
-

--- a/sql/03_create-view.sql
+++ b/sql/03_create-view.sql
@@ -27,6 +27,7 @@ SELECT
     WHEN event->>'realmId' IS NOT NULL          THEN 'legacy'
     WHEN event->>'source_system' = 'LTT'         THEN 'ltt'
     WHEN event->>'schema_version' IS NOT NULL    THEN event->>'schema_version'
+    WHEN event->>'version' IS NOT NULL           THEN event->>'version'
     ELSE 'legacy'
   END AS schema_version,
 


### PR DESCRIPTION
I modified `sql/03_create-view.sql` to improve the determination of the `schema_version` column in the `api.events_view`.

The `CASE` statement for `schema_version` now includes a fallback to use `event->>'version'` if `event->>'schema_version'` is not defined in the event JSON. This allows events that specify their version in a top-level `version` field (like ISACC and dhair2 samples) to be correctly classified by `schema_version`.

This change fixes the failure in `tests/test_views.py::test_view_with_isacc_data` where ISACC sample data was being classified as 'legacy' instead of '3.0'.